### PR TITLE
Compatible with Biome 2.4.x. Does not support Biome 2.3.x or earlier.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This Flycheck extension is an **EXPERIMENTAL PACKAGE** intended to provide JavaS
 
 ## Requirements
 
-* Biome 1.9.0 or later
+* Biome 2.4.0 or later
 
 Please follow the installation instructions in [Biome's Getting Started](https://biomejs.dev/guides/getting-started/) guide.
 

--- a/flycheck-biomejs.el
+++ b/flycheck-biomejs.el
@@ -124,7 +124,7 @@ See `flycheck-define-checker' for the three arguments OUTPUT, CHECKER, and BUFFE
   (and buffer-file-name
        (let* ((command (executable-find "biome"))
               (version (when command (flycheck-biomejs/get-version command)))
-              (version-p (when version (flycheck-biomejs/check-version version "1.9.0")))
+              (version-p (when version (flycheck-biomejs/check-version version "2.4.0")))
               (config-path (flycheck-biomejs/get-config-path)))
          (and version-p config-path))))
 
@@ -132,7 +132,7 @@ See `flycheck-define-checker' for the three arguments OUTPUT, CHECKER, and BUFFE
   "Verify flycheck-biomejs."
   (let* ((command (executable-find "biome"))
          (version (when command (flycheck-biomejs/get-version command)))
-         (version-p (when version (flycheck-biomejs/check-version version "1.9.0")))
+         (version-p (when version (flycheck-biomejs/check-version version "2.4.0")))
          (config-path (and buffer-file-name (flycheck-biomejs/get-config-path))))
     (list
      (flycheck-verification-result-new

--- a/flycheck-biomejs.el
+++ b/flycheck-biomejs.el
@@ -104,15 +104,16 @@ See `flycheck-define-checker' for the three arguments OUTPUT, CHECKER, and BUFFE
   (let ((parsed (flycheck-parse-json (flycheck-biomejs/remove-unstable-message output))))
     (mapcar (lambda (diag)
               (let-alist diag
-                (flycheck-error-new-at-pos
-                 (1+ (car .location.span))
+                (flycheck-error-new-at
+                 .location.start.line
+                 .location.start.column
                  (pcase .severity
                    ((or "error" "fatal") 'error)
                    ((or "information" "hint") 'info)
                    ((or "warning" _) 'warning))
-                 (format "%s(%s)" .description .category)
-                 :end-pos (1+ (cadr .location.span))
-                 ;;:id (cddr (split-string .category "/"))
+                 (format "%s(%s)" .message .category)
+                 :end-line .location.end.line
+                 :end-column .location.end.column
                  :checker checker
                  :buffer buffer
                  :filename (buffer-file-name buffer))))


### PR DESCRIPTION
- The JSON format output by `biome lint --reporter=json` has changed in Biome 2.4.0
- We will no longer support Biome 2.3.x or earlier versions
  - Requires Biome 2.4.0 or later

Biome 2.4.0で`biome lint --reporter=json`で出力されるJSON形式が変更になった。
これによりBiome 2.3.x以前の対応をやめる。